### PR TITLE
Fix tests for Node > 10

### DIFF
--- a/test.js
+++ b/test.js
@@ -31,19 +31,19 @@ describe('zeropad', function(){
     it('throws when num is NaN', function(){
         assert.throws(function(){
             zp({}, 1);
-        }, 'zeropad requires a number or string');
+        }, 'a number or string is required by zeropad');
     });
 
     it('throws when length is NaN', function(){
         assert.throws(function(){
             zp(1, {});
-        }, 'zeropad requires a positive integer for length');
+        }, 'a positive integer for length is required by zeropad');
     });
 
     it('throws on negative length', function(){
         assert.throws(function(){
             zp(1, -1);
-        }, 'zeropad requires a positive integer for length');
+        }, 'a positive integer for length is required by zeropad');
     });
 
     it('length is optional', function(){


### PR DESCRIPTION
Tests fail:
```
  4 passing (9ms)
  3 failing
  1) zeropad throws when num is NaN:
     TypeError [ERR_AMBIGUOUS_ARGUMENT]: The "error/message" argument is ambiguous. The error message "zeropad requires a number or string" is identical to the message.
      at expectsError (assert.js:615:15)
      at Function.throws (assert.js:676:3)
      at Context.<anonymous> (test.js:32:16)
  2) zeropad throws when length is NaN:
     TypeError [ERR_AMBIGUOUS_ARGUMENT]: The "error/message" argument is ambiguous. The error message "zeropad requires a positive integer for length" is identical to the message.
      at expectsError (assert.js:615:15)
      at Function.throws (assert.js:676:3)
      at Context.<anonymous> (test.js:38:16)
  3) zeropad throws on negative length:
     TypeError [ERR_AMBIGUOUS_ARGUMENT]: The "error/message" argument is ambiguous. The error message "zeropad requires a positive integer for length" is identical to the message.
      at expectsError (assert.js:615:15)
      at Function.throws (assert.js:676:3)
      at Context.<anonymous> (test.js:44:16)
```
Node v10 has some additional assert sanity checks: if the thrown error message text equals the assert function call's descriptive message text argument, it reports this error. This PR just change the the error message text.